### PR TITLE
Refer expo-cli instead of create-react-native-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@
 
 The Vue Native CLI is used to generate a `Vue Native` app, which is a React Native API wrapper. This means that with Vue Native, you can do anything that could be done with React Native.
 
-The Vue Native CLI generates a simple single page application (SPA) using [create-react-native-app](https://github.com/react-community/create-react-native-app) and
+The Vue Native CLI generates a simple single page application (SPA) using [expo-cli](https://github.com/expo/expo-cli) and
 [vue-native-core](https://github.com/GeekyAnts/vue-native-core).
 
 ## Installation Prerequisites
 
-You should have create-react-native-app or react-native-cli installed as a global dependency
+You should have expo-cli or react-native-cli installed as a global dependency
 
 ```
 For React Native ClI => npm install react-native-cli -g
 ```
 
 ```
-For CRNA => npm install create-react-native-app -g
+For CRNA => npm install expo-cli -g
 ```
 
 ## Installation:


### PR DESCRIPTION
Hi, I'm a vue-native new comer 😄  

I tried

```shell-session
$ npm install -g react-native-cli create-react-native-app vue-native-cli
$ vue-native init vue-calculator
```

but got

```
Error In Getting Crna Package Version { Error: Command failed: expo --version 2>/dev/null
    at checkExecSyncError (child_process.js:618:11)
    at execSync (child_process.js:655:13)
    at Object.getCrnaVersionIfAvailable (/usr/local/lib/node_modules/vue-native-cli/src/utils/validation.js:62:9)
    at Command.<anonymous> (/usr/local/lib/node_modules/vue-native-cli/src/index.js:31:63)
    at Command.listener (/usr/local/lib/node_modules/vue-native-cli/node_modules/commander/index.js:315:8)
    at Command.emit (events.js:182:13)
    at Command.parseArgs (/usr/local/lib/node_modules/vue-native-cli/node_modules/commander/index.js:651:12)
    at Command.parse (/usr/local/lib/node_modules/vue-native-cli/node_modules/commander/index.js:474:21)
    at Object.<anonymous> (/usr/local/lib/node_modules/vue-native-cli/src/index.js:70:9)
    at Module._compile (internal/modules/cjs/loader.js:707:30)
  status: 127,
  signal: null,
  output: [ null, <Buffer >, <Buffer > ],
  pid: 55847,
  stdout: <Buffer >,
  stderr: <Buffer > }
Please globally install create-react-native-app dependency
```

After this, I confirmed that [the create-react-native-app repository](https://github.com/react-community/create-react-native-app) is now archived.

Also I solved the problem by below

```shell-session
$ npm uninstall -g create-react-native-app
$ npm install expo-cli
$ vue-native init vue-calculator
    ('vue-calculator' created successfully.)
```

I think vue-native should refer expo-cli.

But I have no knowledge for vue-native, I'm a new comer.
Please close this PR if my opinion is wrong :pray:

- - -

Maybe related

- [Installation — Vue Native](https://vue-native.io/docs/installation.html) suggests installing create-react-native-app.
