### PR TITLE
Updated parseCss.js to ignore rules without declarations or selectors

### DIFF
--- a/packages/vue-native-scripts/src/util/parseCss.js
+++ b/packages/vue-native-scripts/src/util/parseCss.js
@@ -6,25 +6,35 @@ function camelize(str) {
   return str.replace(camelizeRE, (_, c) => c ? c.toUpperCase() : '')
 }
 
+function parseDeclarations(declarations) {
+  const declarationObj = {};
+
+  // Comments and @media blocks don't have declarations at the top level.
+  if (declarations) {
+    declarations.forEach(function (declaration) {
+      if (declaration.type === 'declaration') {
+        let value = declaration.value;
+        if (/px$/.test(value)) {
+          value = parseFloat(value.replace(/px$/, ''));
+        } else if (declaration.property !== 'font-weight' &&  isNaN(value) === false){
+          value = parseFloat(value);
+        }
+        if (declaration.property === 'transform') {
+          value = parseTransform(value);
+        }
+        declarationObj[camelize(declaration.property)] = value;
+      }
+    });
+  }
+
+  return declarationObj;
+}
+
 module.exports = function (ast) {
   const obj = {};
   if (ast.type === 'stylesheet') {
     ast.stylesheet.rules.forEach(function (rule) {
-      const declarationObj = {};
-      rule.declarations.forEach(function (declaration) {
-        if (declaration.type === 'declaration') {
-          let value = declaration.value;
-          if (/px$/.test(value)) {
-            value = parseFloat(value.replace(/px$/, ''));
-          } else if (declaration.property !== 'font-weight' &&  isNaN(value) === false){
-            value = parseFloat(value);
-          }
-          if (declaration.property === 'transform') {
-            value = parseTransform(value);
-          }
-          declarationObj[camelize(declaration.property)] = value;
-        }
-      });
+      const declarationObj = parseDeclarations(rule.declarations);
       rule.selectors.forEach(function (selector) {
         if (selector.indexOf('.') === 0) {
           obj[selector.replace(/^\./, '')] = declarationObj;

--- a/packages/vue-native-scripts/src/util/parseCss.js
+++ b/packages/vue-native-scripts/src/util/parseCss.js
@@ -35,11 +35,13 @@ module.exports = function (ast) {
   if (ast.type === 'stylesheet') {
     ast.stylesheet.rules.forEach(function (rule) {
       const declarationObj = parseDeclarations(rule.declarations);
-      rule.selectors.forEach(function (selector) {
-        if (selector.indexOf('.') === 0) {
-          obj[selector.replace(/^\./, '')] = declarationObj;
-        }
-      });
+      if (rule.selectors) {
+        rule.selectors.forEach(function (selector) {
+          if (selector.indexOf('.') === 0) {
+            obj[selector.replace(/^\./, '')] = declarationObj;
+          }
+        });
+      }
     });
   }
   return obj;


### PR DESCRIPTION
… at the top level (such as comments and @media blocks).

Also, extracted a new parseDeclarations() function.