### PR TITLE
Updated the vue-native-template-compiler version

### DIFF
--- a/packages/vue-native-scripts/package.json
+++ b/packages/vue-native-scripts/package.json
@@ -20,7 +20,7 @@
     "line-number": "^0.1.0",
     "node-watch": "^0.5.4",
     "parse5": "^5.0.0",
-    "vue-native-template-compiler": "^0.0.12",
+    "vue-native-template-compiler": "^0.0.13",
     "walk": "^2.3.9"
   },
   "devDependencies": {


### PR DESCRIPTION
Updated the vue-native-template-compiler version that vue-native-scripts depends on to be 0.0.13.

See issue #147 .