### PR TITLE
Replace all whitespace in Text nodes with a single space (fixes #164)

### DIFF
--- a/packages/vue-native-template-compiler/build.js
+++ b/packages/vue-native-template-compiler/build.js
@@ -2168,12 +2168,6 @@ function filterDirectiveBindProps (ast) {
   }
 }
 
-function transformSpecialNewlines (text) {
-  return text
-    .replace(/\u2028/g, '\\u2028')
-    .replace(/\u2029/g, '\\u2029')
-}
-
 var BaseGenerator = function BaseGenerator (ast, options) {
   this.ast = ast;
   this.variableDependency = [];
@@ -3272,7 +3266,8 @@ var RenderGenerator = /*@__PURE__*/(function (BaseGenerator) {
    * @param {Object} ast
    */
   RenderGenerator.prototype.genText = function genText (ast) {
-    var text = transformSpecialNewlines(ast.text);
+    // Replace all whitespace with a single space.
+    var text = ast.text.replace(/\s+/g, " ");
     return JSON.stringify(text);
   };
 

--- a/src/platforms/vue-native/compiler/codegen/RenderGenerator.js
+++ b/src/platforms/vue-native/compiler/codegen/RenderGenerator.js
@@ -6,8 +6,7 @@ import { isReservedTag, isBooleanAttr } from "../util/index";
 import BaseGenerator from "./BaseGenerator";
 import {
   filterDirective,
-  filterDirectiveBindProps,
-  transformSpecialNewlines
+  filterDirectiveBindProps
 } from "vue-native/compiler/helpers";
 import { parseText } from "vue-native/compiler/parser/text-parser";
 import propertyMap from "vue-native/compiler/property/index";
@@ -145,7 +144,8 @@ class RenderGenerator extends BaseGenerator {
    * @param {Object} ast
    */
   genText(ast) {
-    const text = transformSpecialNewlines(ast.text);
+    // Replace all whitespace with a single space.
+    const text = ast.text.replace(/\s+/g, " ");
     return JSON.stringify(text);
   }
 

--- a/src/platforms/vue-native/compiler/helpers.js
+++ b/src/platforms/vue-native/compiler/helpers.js
@@ -55,9 +55,3 @@ export function filterDirectiveBindProps (ast) {
     return []
   }
 }
-
-export function transformSpecialNewlines (text) {
-  return text
-    .replace(/\u2028/g, '\\u2028')
-    .replace(/\u2029/g, '\\u2029')
-}


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions \s includes \u2028 and \u2029 .

Fixes issue #164.