### PR TITLE
Added ImageStore to list of deprecated packages. Fix for #161

### DIFF
--- a/packages/vue-native-helper/build.js
+++ b/packages/vue-native-helper/build.js
@@ -295,7 +295,8 @@ function def(obj, key, val, enumerable) {
   'ViewPagerAndroid',
   'ListView',
   'SwipeableListView',
-  'Slider'
+  'Slider',
+  'ImageStore'
  ];
 
 /**


### PR DESCRIPTION
This PR is a fix for #161. I added ImageStore to the list of deprecated packages. This removes the error message that is constantly displayed during building/deploying of a vue-native project. 

If this PR needs to be updated or changed, please let me know and I'll make the changes accordingly. Thanks. 