### PR TITLE
Release tag v0.1.2

### DIFF
--- a/packages/vue-native-scripts/package.json
+++ b/packages/vue-native-scripts/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {},
   "bin": {
-    "vue-native-scripts": "./src/bin/vue-native-script.js"
+    "vue-native-scripts": "./bin/vue-native-script.js"
   },
   "author": "Geekyants (https://geekyants.io/)",
   "license": "MIT",


### PR DESCRIPTION
This PR mainly contains a fix for a bug that would make `npm install` fail.

### Bug fixes
- Fixed #182 and #191 by correcting the path to `vue-native-scripts`' executable (in "bin" in the `package.json`)

### Known issues
- Expo users using SDK ^33 or projects generated with `expo-cli` ^3.0.0 may still face an app crash on starting the development server. This happens due to a bug in Expo which ignores the `sourceExts` in `metro.config.js`. A manual change is required in `app.json` as described in #183 

