### PR TITLE
Release script

### DIFF
--- a/build/release.sh
+++ b/build/release.sh
@@ -1,23 +1,11 @@
 set -e
 
 # check if np is installed
-# if not, prompt the user to install it
 np_version=$(np --version)
-if [[ $? -eq 0 ]]; then
-  echo "Using np version: " $np_version
-else
-  echo "np is not installed"
-  read -e -p "Install globally? (Executes: npm install -global np) [y/n]" REPLY
-  if [[ $REPLY =~ ^(y|yes)$ ]]; then
-    npm install -global np
-  elif [[ $REPLY =~ ^(n|no)$ ]]; then
-    echo "Exiting..."
-    exit 1
-  fi
-fi
+echo "Using np:" $np_version
 
 # get the version number from the user
-read -e -p "Enter the new version" VERSION
+read -e -p "Enter the new Vue Native version: " VERSION
 if [[ -z $VERSION ]]; then
   echo "No version entered. Exiting..."
   exit 0

--- a/build/release.sh
+++ b/build/release.sh
@@ -1,10 +1,26 @@
 set -e
 
-if [[ -z $1 ]]; then
-  echo "Enter new version: "
-  read VERSION
+# check if np is installed
+# if not, prompt the user to install it
+np_version=$(np --version)
+if [[ $? -eq 0 ]]; then
+  echo "Using np version: " $np_version
 else
-  VERSION=$1
+  echo "np is not installed"
+  read -e -p "Install globally? (Executes: npm install -global np) [y/n]" REPLY
+  if [[ $REPLY =~ ^(y|yes)$ ]]; then
+    npm install -global np
+  elif [[ $REPLY =~ ^(n|no)$ ]]; then
+    echo "Exiting..."
+    exit 1
+  fi
+fi
+
+# get the version number from the user
+read -e -p "Enter the new version" VERSION
+if [[ -z $VERSION ]]; then
+  echo "No version entered. Exiting..."
+  exit 0
 fi
 
 read -p "Releasing $VERSION - are you sure? (y/n) " -n 1 -r
@@ -12,50 +28,62 @@ echo
 if [[ $REPLY =~ ^[Yy]$ ]]; then
   echo "Releasing $VERSION ..."
 
-  npm run lint
-  npm run flow
-  npm run test:cover
-  npm run test:e2e
-  npm run test:ssr
+  # bump package versions
+  # packages:
+  # - vue-native-core
+  # - vue-native-helper
+  # - vue-native-scripts
+  # - vue-native-template-compiler
 
-  if [[ -z $SKIP_SAUCE ]]; then
-    export SAUCE_BUILD_ID=$VERSION:`date +"%s"`
-    npm run test:sauce
-  fi
+  cd packages/vue-native-core
+  npm version $VERSION
+  cd -
+
+  cd packages/vue-native-helper
+  npm version $VERSION
+  cd -
+
+  cd packages/vue-native-scripts
+  npm version $VERSION
+  cd -
+
+  cd packages/vue-native-template-compiler
+  npm version $VERSION
+  cd -
 
   # build
+  # the build needs to be generated after the version bump
+  # because the Vue version comes from packages/vue-native-core/package.json
+  # refer to build/config.js
   VERSION=$VERSION npm run build
-
-  # update packages
-  cd packages/vue-template-compiler
-  npm version $VERSION
-  if [[ -z $RELEASE_TAG ]]; then
-    npm publish
-  else
-    npm publish --tag $RELEASE_TAG
-  fi
-  cd -
-
-  cd packages/vue-server-renderer
-  npm version $VERSION
-  if [[ -z $RELEASE_TAG ]]; then
-    npm publish
-  else
-    npm publish --tag $RELEASE_TAG
-  fi
-  cd -
 
   # commit
   git add -A
   git commit -m "[build] $VERSION"
-  npm version $VERSION --message "[release] $VERSION"
 
-  # publish
-  git push origin refs/tags/v$VERSION
-  git push
-  if [[ -z $RELEASE_TAG ]]; then
-    npm publish
-  else
-    npm publish --tag $RELEASE_TAG
-  fi
+  # use np to create release with VERSION and publish vue-native-core
+  # you MUST be in the master branch to do this
+  # if it fails, then the last commit is reset and the script exits
+  # TODO: add tests and remove --yolo
+  np --no-yarn --contents packages/vue-native-core --yolo $VERSION || { git reset --soft HEAD~1; exit 1; }
+
+  # publish packages
+  # vue-native-core has already been published by np
+  # packages:
+  # - vue-native-helper
+  # - vue-native-scripts
+  # - vue-native-template-compiler
+
+  cd packages/vue-native-helper
+  npm publish
+  cd -
+
+  cd packages/vue-native-scripts
+  npm publish
+  cd -
+
+  cd packages/vue-native-template-compiler
+  npm publish
+  cd -
+
 fi


### PR DESCRIPTION
The release script does the following:
- asks for new version number
- bumps package versions to the specified version
- creates a build
- creates a release commit
- runs `np` to create the release tag and publish `vue-native-core`
- publishes `vue-native-helper`, `vue-native-scripts` and `vue-native-template-compiler` with `npm publish`

If `np` fails, then the release commit is reset and the script exits.

No tests or linting written yet, so `np` uses the `--yolo` flag. This will be removed later.
