### PR TITLE
Release tag v0.1.4

### DIFF
--- a/build/config.js
+++ b/build/config.js
@@ -52,7 +52,7 @@ const builds = {
     entry: resolve("vue-native/compiler.js"),
     dest: resolve("packages/vue-native-template-compiler/build.js"),
     format: "cjs",
-    external: ["change-case", "he", "de-indent"],
+    external: ["change-case", "he", "de-indent", "lodash"],
   }
 };
 

--- a/build/release.sh
+++ b/build/release.sh
@@ -1,10 +1,14 @@
 set -e
 
-if [[ -z $1 ]]; then
-  echo "Enter new version: "
-  read VERSION
-else
-  VERSION=$1
+# check if np is installed
+np_version=$(np --version)
+echo "Using np:" $np_version
+
+# get the version number from the user
+read -e -p "Enter the new Vue Native version: " VERSION
+if [[ -z $VERSION ]]; then
+  echo "No version entered. Exiting..."
+  exit 0
 fi
 
 read -p "Releasing $VERSION - are you sure? (y/n) " -n 1 -r
@@ -12,50 +16,62 @@ echo
 if [[ $REPLY =~ ^[Yy]$ ]]; then
   echo "Releasing $VERSION ..."
 
-  npm run lint
-  npm run flow
-  npm run test:cover
-  npm run test:e2e
-  npm run test:ssr
+  # bump package versions
+  # packages:
+  # - vue-native-core
+  # - vue-native-helper
+  # - vue-native-scripts
+  # - vue-native-template-compiler
 
-  if [[ -z $SKIP_SAUCE ]]; then
-    export SAUCE_BUILD_ID=$VERSION:`date +"%s"`
-    npm run test:sauce
-  fi
+  cd packages/vue-native-core
+  npm version $VERSION
+  cd -
+
+  cd packages/vue-native-helper
+  npm version $VERSION
+  cd -
+
+  cd packages/vue-native-scripts
+  npm version $VERSION
+  cd -
+
+  cd packages/vue-native-template-compiler
+  npm version $VERSION
+  cd -
 
   # build
+  # the build needs to be generated after the version bump
+  # because the Vue version comes from packages/vue-native-core/package.json
+  # refer to build/config.js
   VERSION=$VERSION npm run build
-
-  # update packages
-  cd packages/vue-template-compiler
-  npm version $VERSION
-  if [[ -z $RELEASE_TAG ]]; then
-    npm publish
-  else
-    npm publish --tag $RELEASE_TAG
-  fi
-  cd -
-
-  cd packages/vue-server-renderer
-  npm version $VERSION
-  if [[ -z $RELEASE_TAG ]]; then
-    npm publish
-  else
-    npm publish --tag $RELEASE_TAG
-  fi
-  cd -
 
   # commit
   git add -A
   git commit -m "[build] $VERSION"
-  npm version $VERSION --message "[release] $VERSION"
 
-  # publish
-  git push origin refs/tags/v$VERSION
-  git push
-  if [[ -z $RELEASE_TAG ]]; then
-    npm publish
-  else
-    npm publish --tag $RELEASE_TAG
-  fi
+  # use np to create release with VERSION and publish vue-native-core
+  # you MUST be in the master branch to do this
+  # if it fails, then the last commit is reset and the script exits
+  # TODO: add tests and remove --yolo
+  np --no-yarn --contents packages/vue-native-core --yolo $VERSION || { git reset --soft HEAD~1; exit 1; }
+
+  # publish packages
+  # vue-native-core has already been published by np
+  # packages:
+  # - vue-native-helper
+  # - vue-native-scripts
+  # - vue-native-template-compiler
+
+  cd packages/vue-native-helper
+  npm publish
+  cd -
+
+  cd packages/vue-native-scripts
+  npm publish
+  cd -
+
+  cd packages/vue-native-template-compiler
+  npm publish
+  cd -
+
 fi

--- a/converting-react-native-project.md
+++ b/converting-react-native-project.md
@@ -45,6 +45,29 @@ module.exports = (async () => {
 })();
 ```
 
+#### NOTE to Expo users:
+
+The `app.json` file must be modified to allow `.vue` files to be recognised.
+
+```diff
+{
+  "expo": {
+    "sdkVersion": "34.0.0",
+    "platforms": [
+      "ios",
+      "android",
+      "web"
+    ],
+    ...
+    "packagerOpts": {
++     "sourceExts": ["js", "json", "ts", "tsx", "vue"],
+      "config": "metro.config.js"
+    }
+  }
+}
+```
+
+
 The `babelTransformPath` property above takes the path to the transformer you wish to use. In our case, we need to create a `vueTransformerPlugin.js` file to the project's root and specify supported extensions:
 
 ```js

--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -8,6 +8,8 @@ import { cached, no, camelize } from 'shared/util'
 import { genAssignmentCode } from '../directives/model'
 import { isIE, isEdge, isServerRendering, isNative } from 'core/util/env'
 
+import ReactNativeRenderGenerator from 'vue-native/compiler/codegen/NativeRenderGenerator.js'
+
 import {
   addProp,
   addAttr,
@@ -549,7 +551,7 @@ export function processAttrs (el, options, customSlot = false) {
         ) {
           // Add Attribute in parent element
           //
-          var renderer = new ReactNativeRenderGenerator(el, options);
+          const renderer = new ReactNativeRenderGenerator(el, options);
           let customRenderer = renderer.generateRender();
           let customImport = renderer.generateImport();
           customRenderer = customRenderer.replace(

--- a/src/platforms/vue-native/compiler/native.js
+++ b/src/platforms/vue-native/compiler/native.js
@@ -1,3 +1,5 @@
+import _ from 'lodash'
+
 import { parse, processAttrs } from "compiler/parser/index";
 
 import { NativeRenderGenerator } from "vue-native/compiler/codegen/index";


### PR DESCRIPTION
This release contains a bug fix and some improvements to the documentation. It also adds a release script.

### Bug fixes
- Fixed a crash that occurred when `render-prop` or `render-prop-fn` was used (#190 and #195)

### Improvements
- Modified the release script to make it functional
- Added instructions in the readme for Expo users (#189)